### PR TITLE
Replace DB and Redis checks with netcat; update Docker configs

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -4,22 +4,32 @@ WORKDIR /code
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONPATH="/code:$PYTHONPATH" \
-    DJANGO_SETTINGS_MODULE=core.settings
+    DJANGO_SETTINGS_MODULE=core.settings \
+    DEBIAN_FRONTEND=noninteractive
 
+# Instalacja niezbędnych pakietów systemowych
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    postgresql-client \
+    netcat-traditional \
     && rm -rf /var/lib/apt/lists/*
 
+# Instalacja zależności Pythona
 COPY ./gateway/requirements.txt /code/requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Kopiowanie kodu aplikacji
 COPY ./gateway /code/
 COPY ./shared /code/shared
 COPY ./scripts/generate_proto_files.sh /code/generate_proto_files.sh
 COPY ./gateway/entrypoint.sh /code/entrypoint.sh
 
+# Nadanie uprawnień wykonywania dla skryptów
 RUN chmod +x /code/generate_proto_files.sh /code/entrypoint.sh
 
 EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:8000/health/ || exit 1
 
 ENTRYPOINT ["/code/entrypoint.sh"]

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -21,11 +21,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Kopiowanie kodu aplikacji
 COPY ./gateway /code/
 COPY ./shared /code/shared
-COPY ./scripts/generate_proto_files.sh /code/generate_proto_files.sh
 COPY ./gateway/entrypoint.sh /code/entrypoint.sh
-
-# Nadanie uprawnień wykonywania dla skryptów
-RUN chmod +x /code/generate_proto_files.sh /code/entrypoint.sh
 
 EXPOSE 8000
 

--- a/gateway/entrypoint.sh
+++ b/gateway/entrypoint.sh
@@ -3,8 +3,7 @@ set -e
 
 # Czekaj na dostępność bazy danych
 echo "Waiting for database..."
-until pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER"
-do
+while ! nc -z $DB_HOST $DB_PORT; do
     echo "Database is unavailable - sleeping"
     sleep 1
 done
@@ -12,24 +11,11 @@ echo "Database started"
 
 # Czekaj na dostępność Redis
 echo "Waiting for Redis..."
-python << END
-import sys
-import redis
-import time
-import os
-
-redis_url = os.environ.get('REDIS_URL')
-
-while True:
-    try:
-        redis_client = redis.from_url(redis_url)
-        redis_client.ping()
-        break
-    except redis.ConnectionError:
-        print("Redis is unavailable - sleeping")
-        time.sleep(1)
-print("Redis started")
-END
+while ! nc -z $REDIS_HOST $REDIS_PORT; do
+    echo "Redis is unavailable - sleeping"
+    sleep 1
+done
+echo "Redis started"
 
 # Zastosuj migracje
 echo "Applying database migrations..."


### PR DESCRIPTION
Replaced `pg_isready` and Python Redis health checks with `netcat` for a simpler approach. Updated the Dockerfile to include `netcat-traditional`, added a health check, and polished comments for better maintainability. These changes streamline dependencies and improve container readiness validation.