### PR TITLE
Add curl and dos2unix to Dockerfile and update entrypoint script

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     postgresql-client \
     netcat-traditional \
+    curl \
+    dos2unix \
     && rm -rf /var/lib/apt/lists/*
 
 # Instalacja zależności Pythona
@@ -23,9 +25,14 @@ COPY ./gateway /code/
 COPY ./shared /code/shared
 COPY ./gateway/entrypoint.sh /code/entrypoint.sh
 
+# Popraw line endings i ustaw uprawnienia
+RUN dos2unix /code/entrypoint.sh && \
+    chmod +x /code/entrypoint.sh && \
+    chown root:root /code/entrypoint.sh
+
 EXPOSE 8000
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/health/ || exit 1
 
-ENTRYPOINT ["/code/entrypoint.sh"]
+ENTRYPOINT bash /code/entrypoint.sh


### PR DESCRIPTION
Added `curl` and `dos2unix` dependencies to the Dockerfile for improved script handling. Normalized line endings, adjusted permissions, and changed ownership for `entrypoint.sh` to ensure compatibility and proper execution. Updated the entrypoint command to invoke the script via bash.