### PR TITLE
Remove unused Docker image build and deployment steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,28 +30,6 @@ jobs:
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/plantigo-gateway:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/plantigo-gateway:${{ github.sha }}
-
-#      - name: Build and push devices Docker image
-#        uses: docker/build-push-action@v5
-#        with:
-#          context: .
-#          file: ./devices/Dockerfile
-#          push: true
-#          tags: |
-#            ${{ secrets.DOCKERHUB_USERNAME }}/plantigo-devices:latest
-#            ${{ secrets.DOCKERHUB_USERNAME }}/plantigo-devices:${{ github.sha }}
-#
-#      - name: Build and push telemetry Docker image
-#        uses: docker/build-push-action@v5
-#        with:
-#          context: .
-#          file: ./telemetry/Dockerfile
-#          push: true
-#          tags: |
-#            ${{ secrets.DOCKERHUB_USERNAME }}/plantigo-telemetry:latest
-#            ${{ secrets.DOCKERHUB_USERNAME }}/plantigo-telemetry:${{ github.sha }}
-#
-
       - name: Deploy to VPS
         uses: appleboy/ssh-action@master
         with:
@@ -62,13 +40,8 @@ jobs:
             cd /root/plantigo/plantigo-backend
 
             docker tag ${{ secrets.DOCKERHUB_USERNAME }}/plantigo-gateway:latest ${{ secrets.DOCKERHUB_USERNAME }}/plantigo-gateway:rollback || true
-#            docker tag ${{ secrets.DOCKERHUB_USERNAME }}/plantigo-devices:latest ${{ secrets.DOCKERHUB_USERNAME }}/plantigo-devices:rollback || true
-#            docker tag ${{ secrets.DOCKERHUB_USERNAME }}/plantigo-telemetry:latest ${{ secrets.DOCKERHUB_USERNAME }}/plantigo-telemetry:rollback || true
 
             docker pull ${{ secrets.DOCKERHUB_USERNAME }}/plantigo-gateway:latest
-#            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/plantigo-devices:latest
-#            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/plantigo-telemetry:latest
-
             
             docker compose -f docker-compose.yml down
             docker compose -f docker-compose.yml up -d


### PR DESCRIPTION
Commented out steps for building and deploying 'devices' and 'telemetry' Docker images have been removed for cleanup and simplification. These steps are no longer necessary, focusing the workflow solely on the 'gateway' service.