### PR TITLE
Add signal to update device status and adjust activity window

### DIFF
--- a/gateway/devices/apps.py
+++ b/gateway/devices/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class DevicesConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'devices'
+
+    def ready(self):
+        import devices.signals

--- a/gateway/devices/models.py
+++ b/gateway/devices/models.py
@@ -98,7 +98,7 @@ class Device(BaseModel):
     )
     is_active = models.BooleanField(
         default=False,
-        help_text="Indicates if device is active (has sent data in last 5 minutes)"
+        help_text="Indicates if device is active (has sent data in last 4 hours)"
     )
 
     class Meta:
@@ -114,7 +114,7 @@ class Device(BaseModel):
     def update_active_status(self) -> bool:
         """Updates the is_active status based on recent telemetry data."""
         has_recent_data = self.telemetry.filter(
-            timestamp__gte=timezone.now() - timedelta(hours=24)
+            timestamp__gte=timezone.now() - timedelta(hours=4)
         ).exists()
         if self.is_active != has_recent_data:
             self.is_active = has_recent_data

--- a/gateway/devices/signals.py
+++ b/gateway/devices/signals.py
@@ -1,0 +1,8 @@
+from django.dispatch import receiver
+from devices.models import Telemetry
+from django.db.models.signals import post_save
+
+
+@receiver(post_save, sender=Telemetry)
+def update_device_status(sender, instance, **kwargs):
+    instance.device.update_active_status()


### PR DESCRIPTION
Introduce a Django signal to automatically update the device's `is_active` status upon saving new telemetry data. Adjust the active status window from 24 hours to 4 hours for more timely updates on device activity.