### PR TITLE
Remove redundant shared folder copy from Dockerfile

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -22,7 +22,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Kopiowanie kodu aplikacji
 COPY ./gateway /code/
-COPY ./shared /code/shared
 COPY ./gateway/entrypoint.sh /code/entrypoint.sh
 
 # Popraw line endings i ustaw uprawnienia


### PR DESCRIPTION
The shared folder is no longer required for the gateway service. Removing this line simplifies the Dockerfile and avoids copying unnecessary files.