### PR TITLE
Enable authentication for telemetry creation

### DIFF
--- a/gateway/devices/views.py
+++ b/gateway/devices/views.py
@@ -77,7 +77,7 @@ class TelemetryViewSet(mixins.CreateModelMixin,
     create:
         Add new telemetry data
     """
-    # permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated]
     serializer_class = TelemetrySerializer
 
     def get_queryset(self):


### PR DESCRIPTION
Restore authentication requirement for telemetry endpoint by uncommenting permission_classes