### PR TITLE
Add hard delete method to BaseModel and DeviceViewSet

### DIFF
--- a/gateway/core/models.py
+++ b/gateway/core/models.py
@@ -17,6 +17,9 @@ class BaseModel(models.Model):
         self.is_deleted = True
         self.save()
 
+    def hard_delete(self):
+        super().delete()
+
     def restore(self):
         self.is_deleted = False
         self.save()

--- a/gateway/devices/views.py
+++ b/gateway/devices/views.py
@@ -24,7 +24,7 @@ class DeviceViewSet(viewsets.ModelViewSet):
     partial_update:
         Update specific device fields (PATCH)
     delete:
-        Remove device
+        Remove device (hard delete)
     """
     permission_classes = [IsAuthenticated]
     serializer_class = DeviceSerializer
@@ -49,6 +49,12 @@ class DeviceViewSet(viewsets.ModelViewSet):
     def partial_update(self, request, *args, **kwargs):
         kwargs['partial'] = True
         return self.update(request, *args, **kwargs)
+
+    def destroy(self, request, *args, **kwargs):
+        """Perform hard delete of the device."""
+        instance = self.get_object()
+        instance.hard_delete()
+        return Response(status=204)
 
     @action(detail=True, methods=['get'])
     def history(self, request, pk=None):


### PR DESCRIPTION
Implement hard delete functionality:
- Add `hard_delete()` method to BaseModel to directly delete model instances
- Update DeviceViewSet's `destroy()` method to use hard delete
- Update docstring to clarify device deletion behavior